### PR TITLE
Improve query performance to get services/operations and use milliseconds for timestamp

### DIFF
--- a/plugin/s3spanstore/reader.go
+++ b/plugin/s3spanstore/reader.go
@@ -202,6 +202,11 @@ func (r *Reader) FindTraces(ctx context.Context, query *spanstore.TraceQueryPara
 		return nil, fmt.Errorf("failed to query trace ids: %w", err)
 	}
 
+	// Short-circuit if we don't find any matching traces.
+	if len(traceIDs) == 0 {
+		return []*model.Trace{}, nil
+	}
+
 	if query.StartTimeMin.IsZero() {
 		query.StartTimeMin = r.DefaultMinTime()
 	}

--- a/plugin/s3spanstore/spanrecord.go
+++ b/plugin/s3spanstore/spanrecord.go
@@ -12,14 +12,15 @@ import (
 
 // SpanRecord contains queryable properties from the span and the span as json payload
 type SpanRecord struct {
-	TraceID       string            `parquet:"name=trace_id, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN"`
-	SpanID        string            `parquet:"name=span_id, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN"`
-	OperationName string            `parquet:"name=operation_name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
-	SpanKind      string            `parquet:"name=span_kind, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
-	StartTime     int64             `parquet:"name=start_time, type=INT64"`
-	Duration      int64             `parquet:"name=duration, type=INT64"`
-	Tags          map[string]string `parquet:"name=tags, type=MAP, convertedtype=MAP, keytype=BYTE_ARRAY, keyconvertedtype=UTF8, valuetype=BYTE_ARRAY, valueconvertedtype=UTF8"`
-	ServiceName   string            `parquet:"name=service_name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	TraceID       string `parquet:"name=trace_id, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN"`
+	SpanID        string `parquet:"name=span_id, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN"`
+	OperationName string `parquet:"name=operation_name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	SpanKind      string `parquet:"name=span_kind, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	// StartTime must have millisecond (int32) percision to worth with Athena engine version 3.
+	StartTime   int32             `parquet:"name=start_time, type=INT32"`
+	Duration    int64             `parquet:"name=duration, type=INT64"`
+	Tags        map[string]string `parquet:"name=tags, type=MAP, convertedtype=MAP, keytype=BYTE_ARRAY, keyconvertedtype=UTF8, valuetype=BYTE_ARRAY, valueconvertedtype=UTF8"`
+	ServiceName string            `parquet:"name=service_name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
 
 	// TODO: Write binary
 	SpanPayload string                 `parquet:"name=span_payload, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN"`
@@ -113,7 +114,7 @@ func NewSpanRecordFromSpan(span *model.Span) (*SpanRecord, error) {
 		SpanID:        span.SpanID.String(),
 		OperationName: span.OperationName,
 		SpanKind:      kind,
-		StartTime:     span.StartTime.UnixMilli(),
+		StartTime:     int32(span.StartTime.UnixMilli()),
 		Duration:      span.Duration.Nanoseconds(),
 		Tags:          kvToMap(searchableTags),
 		ServiceName:   span.Process.ServiceName,

--- a/plugin/s3spanstore/spanrecord.go
+++ b/plugin/s3spanstore/spanrecord.go
@@ -16,7 +16,7 @@ type SpanRecord struct {
 	SpanID        string `parquet:"name=span_id, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN"`
 	OperationName string `parquet:"name=operation_name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
 	SpanKind      string `parquet:"name=span_kind, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
-	// StartTime must have millisecond (int32) percision to worth with Athena engine version 3.
+	// StartTime must have millisecond (int32) precision to work with Athena engine version 3.
 	StartTime   int32             `parquet:"name=start_time, type=INT32"`
 	Duration    int64             `parquet:"name=duration, type=INT64"`
 	Tags        map[string]string `parquet:"name=tags, type=MAP, convertedtype=MAP, keytype=BYTE_ARRAY, keyconvertedtype=UTF8, valuetype=BYTE_ARRAY, valueconvertedtype=UTF8"`


### PR DESCRIPTION
The query to get the services and operation was then being processed
in-memory to get a unique list of services or operations. This ended
up taking ages because we were iterating over ~12 million rows.
Instead, use two separate queries and do the uniquifying in Athena.

I also changed the start time to being stored as an int32, rather than
an int64. I can't validate this without shipping the collector (the
thing that writes) but my what I've read, int32 is the precision for
millisecond, whereas int64 is microsecond precision. Athena only
supports millisecond precision and in v3 of its engine (required for
query reuse) a timestamp with the wrong precision is an error.