### PR TITLE
Store `StartTime` as an int64 with metadata that it is a timestamp in…

### DIFF
--- a/plugin/s3spanstore/spanrecord.go
+++ b/plugin/s3spanstore/spanrecord.go
@@ -16,8 +16,8 @@ type SpanRecord struct {
 	SpanID        string `parquet:"name=span_id, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN"`
 	OperationName string `parquet:"name=operation_name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
 	SpanKind      string `parquet:"name=span_kind, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
-	// StartTime must have millisecond (int32) precision to work with Athena engine version 3.
-	StartTime   int32             `parquet:"name=start_time, type=INT32"`
+	// StartTime must have millisecond precision to work with Athena engine version 3.
+	StartTime   int64             `parquet:"name=start_time, type=INT64, convertedtype=TIMESTAMP_MILLIS"`
 	Duration    int64             `parquet:"name=duration, type=INT64"`
 	Tags        map[string]string `parquet:"name=tags, type=MAP, convertedtype=MAP, keytype=BYTE_ARRAY, keyconvertedtype=UTF8, valuetype=BYTE_ARRAY, valueconvertedtype=UTF8"`
 	ServiceName string            `parquet:"name=service_name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
@@ -114,7 +114,7 @@ func NewSpanRecordFromSpan(span *model.Span) (*SpanRecord, error) {
 		SpanID:        span.SpanID.String(),
 		OperationName: span.OperationName,
 		SpanKind:      kind,
-		StartTime:     int32(span.StartTime.UnixMilli()),
+		StartTime:     span.StartTime.UnixMilli(),
 		Duration:      span.Duration.Nanoseconds(),
 		Tags:          kvToMap(searchableTags),
 		ServiceName:   span.Process.ServiceName,


### PR DESCRIPTION
Store `StartTime` as an int64 with metadata that it is a timestamp in millis. The number of milliseconds since unix epoch long exceeded so this will always overflow :facepalm:.